### PR TITLE
[test-coverage] models/comparison.py: 85% — subtotal/total styling a

### DIFF
--- a/tests/test_models_comparison.py
+++ b/tests/test_models_comparison.py
@@ -3,7 +3,7 @@
 import pytest
 from openpyxl import Workbook
 
-from excel_model.models.comparison import build_comparison
+from excel_model.models.comparison import _entity_col_index, build_comparison
 from excel_model.spec import (
     EntityDef,
     InputsDef,
@@ -177,3 +177,164 @@ def test_comparison_constant_values(comparison_spec, style):
             if cell.value == 0:
                 found_zero = True
     assert found_zero, "No constant value 0 found in Model sheet"
+
+
+def _build_wb(spec, style):
+    wb = Workbook()
+    if "Sheet" in wb.sheetnames:
+        del wb["Sheet"]
+    build_comparison(wb, spec, None, style)
+    return wb
+
+
+def _make_spec(line_items, entities):
+    return ModelSpec(
+        model_type="comparison",
+        title="Test Comparison",
+        currency="EUR",
+        granularity="auto",
+        start_period="2025",
+        n_periods=0,
+        n_history_periods=0,
+        assumptions=(),
+        line_items=tuple(line_items),
+        metadata=MetadataDef(preparer="", date="", version="1.0"),
+        scenarios=(),
+        column_groups=(),
+        inputs=InputsDef(source="", period_col="period", sheet="", value_cols={}),
+        entities=tuple(entities),
+        drivers=(),
+    )
+
+
+_ENTITIES = (
+    EntityDef(key="company_a", label="Company A"),
+    EntityDef(key="company_b", label="Company B"),
+)
+
+
+def test_comparison_subtotal_styling(style):
+    spec = _make_spec(
+        line_items=[
+            LineItemDef(
+                key="revenue",
+                label="Revenue",
+                formula_type="constant",
+                formula_params={"value": 100},
+                is_subtotal=False,
+                is_total=False,
+                section="",
+                format="",
+            ),
+            LineItemDef(
+                key="subtotal_rev",
+                label="Subtotal Revenue",
+                formula_type="sum_of_rows",
+                formula_params={"addend_keys": ["revenue"]},
+                is_subtotal=True,
+                is_total=False,
+                section="",
+                format="",
+            ),
+        ],
+        entities=_ENTITIES,
+    )
+    wb = _build_wb(spec, style)
+    ws = wb["Model"]
+    # Find the subtotal label row
+    for row_idx in range(3, 20):
+        if ws.cell(row=row_idx, column=1).value == "Subtotal Revenue":
+            label_cell = ws.cell(row=row_idx, column=1)
+            data_cell = ws.cell(row=row_idx, column=2)
+            assert label_cell.fill.start_color.rgb == "00D6E4F0"
+            assert data_cell.fill.start_color.rgb == "00D6E4F0"
+            return
+    pytest.fail("Subtotal row not found")
+
+
+def test_comparison_total_styling(style):
+    spec = _make_spec(
+        line_items=[
+            LineItemDef(
+                key="revenue",
+                label="Revenue",
+                formula_type="constant",
+                formula_params={"value": 100},
+                is_subtotal=False,
+                is_total=False,
+                section="",
+                format="",
+            ),
+            LineItemDef(
+                key="total_rev",
+                label="Total Revenue",
+                formula_type="sum_of_rows",
+                formula_params={"addend_keys": ["revenue"]},
+                is_subtotal=False,
+                is_total=True,
+                section="",
+                format="",
+            ),
+        ],
+        entities=_ENTITIES,
+    )
+    wb = _build_wb(spec, style)
+    ws = wb["Model"]
+    for row_idx in range(3, 20):
+        if ws.cell(row=row_idx, column=1).value == "Total Revenue":
+            label_cell = ws.cell(row=row_idx, column=1)
+            data_cell = ws.cell(row=row_idx, column=2)
+            assert label_cell.fill.start_color.rgb == "00AED6F1"
+            assert data_cell.fill.start_color.rgb == "00AED6F1"
+            return
+    pytest.fail("Total row not found")
+
+
+def test_comparison_index_to_base_formula(style):
+    spec = _make_spec(
+        line_items=[
+            LineItemDef(
+                key="revenue",
+                label="Revenue",
+                formula_type="constant",
+                formula_params={"value": 100},
+                is_subtotal=False,
+                is_total=False,
+                section="",
+                format="",
+            ),
+            LineItemDef(
+                key="rev_index",
+                label="Revenue Index",
+                formula_type="index_to_base",
+                formula_params={"value_key": "revenue", "base_entity_key": "company_a"},
+                is_subtotal=False,
+                is_total=False,
+                section="",
+                format="",
+            ),
+        ],
+        entities=_ENTITIES,
+    )
+    wb = _build_wb(spec, style)
+    ws = wb["Model"]
+    for row_idx in range(3, 20):
+        if ws.cell(row=row_idx, column=1).value == "Revenue Index":
+            # Company B column (col 3) should have a formula referencing base col B
+            formula = ws.cell(row=row_idx, column=3).value
+            assert isinstance(formula, str)
+            assert formula.startswith("=")
+            assert "/" in formula
+            assert "B" in formula  # base entity column letter
+            return
+    pytest.fail("index_to_base row not found")
+
+
+def test_entity_col_index_known_key(comparison_spec):
+    assert _entity_col_index(comparison_spec, "company_a") == 2
+    assert _entity_col_index(comparison_spec, "company_b") == 3
+    assert _entity_col_index(comparison_spec, "company_c") == 4
+
+
+def test_entity_col_index_unknown_key(comparison_spec):
+    assert _entity_col_index(comparison_spec, "nonexistent") is None


### PR DESCRIPTION
Closes #41

## Summary

Auto-implemented by Claude from issue #41.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)