### PR TITLE
chore: track CVE-2026-4539 in pygments 2.19.2 (ReDoS, no fix available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 * single-quote `data_sheet` references in SUMIFS formulas so names containing spaces produce valid Excel syntax (e.g. `'My Data'!$AO:$AO`); also annotate `DataSheetDef.number_formats` as `Mapping[int, str]` and narrow `SumifsPivotDef.col_dim_values` to `tuple[str | int | float, ...]` ([#89](https://github.com/neuralsignal/excel-model/pull/89))
 
+### Chores
+
+* track CVE-2026-4539 (pygments 2.19.2 ReDoS in `AdlLexer`) in `SECURITY.md`; no upstream fix available at audit time, low severity, not reachable from project code ([#68](https://github.com/neuralsignal/excel-model/issues/68))
+
 ## [0.1.3](https://github.com/neuralsignal/excel-model/compare/v0.1.2...v0.1.3) (2026-04-05)
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security
+
+## Reporting a Vulnerability
+
+Report suspected security issues by opening a private GitHub security advisory
+on this repository. Do not disclose vulnerabilities in public issues.
+
+## Tracked Advisories (no fix available)
+
+Advisories in this list affect a dependency of this project but have no
+upstream fix at the time of the most recent audit. They are tracked here so
+that, once an upstream fix ships, the relevant version pin can be added to
+`pixi.toml` and the entry removed from this list.
+
+### CVE-2026-4539 — pygments 2.19.2 (ReDoS in `AdlLexer`)
+
+- **Severity:** Low (local access required)
+- **Package:** `pygments` 2.19.2 (transitive dev dependency via `pytest`,
+  `mkdocs-material`)
+- **Description:** Inefficient regular expression in `AdlLexer`
+  (`pygments/lexers/archetype.py`) enables regular expression denial of
+  service when syntax-highlighting Archetype Definition Language (ADL)
+  files.
+- **Project impact:** None. `excel-model` does not invoke `AdlLexer` or
+  process ADL files; `pygments` is pulled in only by dev tooling.
+- **Audit date:** 2026-03-30
+- **Upstream tracker:** https://github.com/pygments/pygments/issues
+- **Remediation once fixed:** pin `pygments >= <fixed-version>` in
+  `pixi.toml` and remove this entry.


### PR DESCRIPTION
Closes #68

## Summary

Auto-implemented by Claude from issue #68.

## Test plan

- [ ] Tests pass in CI
- [ ] Code review approved
- [ ] Manual verification (if applicable)